### PR TITLE
Changing PowerShell quoting to double quotes.

### DIFF
--- a/src/powershell-keychain-manager.js
+++ b/src/powershell-keychain-manager.js
@@ -6,7 +6,7 @@ const credManPath = path.resolve(__dirname, '../CredMan.ps1');
 const runCredMan = (cmd, opts) =>
   runPowershell(
     Object.keys(opts).reduce(
-      (cmd, k) => cmd + ` -${k} '${jsStringEscape(opts[k])}'`,
+      (cmd, k) => cmd + ` -${k} "${jsStringEscape(opts[k])}"`,
       `${credManPath} -${cmd}`
     ),
     true


### PR DESCRIPTION
While PowerShell itself does support single quotes as well as double, Windows process creation only honors double quotes, and the [child_process docs](https://nodejs.org/api/child_process.html) recommends double quotes around arguments, not single.

```javascript
exec('"/path/to/test file/test.sh" arg1 arg2');
// Double quotes are used so that the space in the path is not interpreted as
// a delimiter of multiple arguments.
```