### PR TITLE
Fixes password extraction regex

### DIFF
--- a/lib/powershell-keychain-manager.js
+++ b/lib/powershell-keychain-manager.js
@@ -10,7 +10,7 @@ var runCredMan = function runCredMan(cmd, opts) {
     return cmd + (' -' + k + ' "' + jsStringEscape(opts[k]) + '"');
   }, credManPath + ' -' + cmd), true);
 };
-var passwordLineRE = /^[\s\t]*Password[\s\t]*:[\s\t]?'(.*)'/;
+var passwordLineRE = /^[\s\t]*Password[\s\t]*:[\s\t]?('|")?(.*)\1/;
 var createTargetName = function createTargetName(service, account) {
   return service + ';user=' + account;
 };
@@ -29,7 +29,7 @@ module.exports = {
       if (!pwl) {
         throw ErrorManager.create('GET_FAILURE', 'Unknown error finding ' + service + ' password for ' + account + '.');
       }
-      return { username: account, password: pwl.match(passwordLineRE)[1] };
+      return { username: account, password: pwl.match(passwordLineRE)[2] };
     });
   },
   set: function set(service, account, password) {

--- a/src/powershell-keychain-manager.js
+++ b/src/powershell-keychain-manager.js
@@ -11,7 +11,7 @@ const runCredMan = (cmd, opts) =>
     ),
     true
   );
-const passwordLineRE = /^[\s\t]*Password[\s\t]*:[\s\t]?'(.*)'/;
+const passwordLineRE = /^[\s\t]*Password[\s\t]*:[\s\t]?('|")?(.*)\1/;
 const createTargetName = (service, account) => `${service};user=${account}`;
 
 module.exports = {
@@ -34,7 +34,7 @@ module.exports = {
         `Unknown error finding ${service} password for ${account}.`
       );
     }
-    return { username: account, password: pwl.match(passwordLineRE)[1] };
+    return { username: account, password: pwl.match(passwordLineRE)[2] };
   }),
   set: (service, account, password) => runCredMan(
     'AddCred',


### PR DESCRIPTION
This PR corrects an issue with the password extraction regex in the Powershell Keychain manager.  The old version expected that all passwords would be wrapped with single quotes, but our recent fix to correct sub-shell quoting this is no longer the case.  The new extraction regex can handle both the new unquoted format as well as the old style format for backwards compatibility.

To test this change, you can use a JavaScript regex tester with the following sample format (you may also need to enable multiline matching):
```sh
Successfully wrote or updated credentials as:
  UserName  : vinz@clortho.horse
  Password  : pw123
  Target    : vinz@clortho.horse
  Updated   : 2021-01-05 16:28:56 UTC
  Comment   : Last edited by TEST-PC\Administrator on TEST-PC
```

Since regex can get pretty complex, a little extra explanation is in order.  In order to only match matching quotes, we use a capture group (`('|")`) and a capture group reference (`\1`).  This allows us to only collect a matching pair of single or double quotes so that passwords like `'abc123` will not have the leading quote dropped.  There's nothing that can be done about cases of `'abc'` but it also would've caused trouble in the older setup as well and we have to make some reasonable assumptions to get the general case working.  At some distant point in the future we can relax the assumption and remove the quoting match entirely to support arbitrary passwords, but we'll first need all the consumers to set passwords via the updated code.