### PR TITLE
Npm scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clortho",
+  "name": "@cox-automotive/clortho",
   "version": "1.2.2",
   "description": "friendly, OS-appropriate password handling for node scripts",
   "main": "lib/index.js",


### PR DESCRIPTION
This PR renames our package to be under the `@cox-automotive` scope so it does not conflict with the `clortho` npm package that is already on the registry

The new forked module is published at https://www.npmjs.com/package/@cox-automotive/clortho